### PR TITLE
開発用 docker image と Makefile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.gitignore
+.envrc
+
+coverage
+log
+node_modules
+tmp
+tools
+src
+dist

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 IMAGE_NAME ?= image_assembly_line/dev
+NODE_VERSION ?= 12
 
 build:
 	echo "hello"
 
 build_dev_image:
 	docker build -f dev.Dockerfile \
+		--build-arg NODE_VERSION=${NODE_VERSION} \
 		-t ${IMAGE_NAME} .
 
 run_all:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+IMAGE_NAME ?= image_assembly_line/dev
+
+build:
+	echo "hello"
+
+build_dev_image:
+	docker build -f dev.Dockerfile \
+		-t ${IMAGE_NAME} .
+
+run_all:
+	docker run --rm \
+		-v ${PWD}/src:/app/src \
+		-v ${PWD}/dist:/app/dist \
+		-t ${IMAGE_NAME}:latest \
+		sh -c 'npm run all'
+
+build_test:
+	docker run --rm \
+		-v ${PWD}/src:/app/src \
+		-t ${IMAGE_NAME}:latest \
+		sh -c 'npm run build && npm run test'

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,15 @@ build_dev_image:
 run_all:
 	docker run --rm \
 		-v ${PWD}/src:/app/src \
+		-v ${PWD}/lib:/app/lib \
 		-v ${PWD}/dist:/app/dist \
-		-t ${IMAGE_NAME}:latest \
+		-v ${PWD}/__tests__:/app/__tests__ \
 		sh -c 'npm run all'
 
 build_test:
 	docker run --rm \
 		-v ${PWD}/src:/app/src \
+		-v ${PWD}/lib:/app/lib \
+		-v ${PWD}/__tests__:/app/__tests__ \
 		-t ${IMAGE_NAME}:latest \
 		sh -c 'npm run build && npm run test'

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,4 +1,6 @@
-FROM node:12-slim AS base
+ARG NODE_VERSION
+
+FROM node:$NODE_VERSION-slim AS base
 RUN apt update \
     && apt install icu-devtools git sudo curl ca-certificates build-essential unzip openssh-client -y --no-install-recommends
 WORKDIR /app

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,0 +1,8 @@
+FROM node:12-slim AS base
+RUN apt update \
+    && apt install icu-devtools git sudo curl ca-certificates build-essential unzip openssh-client -y --no-install-recommends
+WORKDIR /app
+COPY . .
+
+FROM base AS dev
+RUN npm install


### PR DESCRIPTION
# 開発用イメージの作成

node のインストールとか結構面倒なので、自分のローカルのアプリケーションの変更を開発用のイメージで実行出来るようにしました。

multi-stage build で base と dev を作っていますが、baseは別にしてみんな共有できるように repository 作って上げても良いかも？？

## npm に変更があったとき。最初のとき

```
make build_dev_image
```

## とりあえず実行とテストを流したい時

```
make build_test
```

## PR作成したい時(全ビルドと js の 1ファイル化 、テスト実行)
```
make run_all
```

# 確認方法

- [x] `make build_dev_image` が成功する
- [ ] `make build_test` が成功する
- [ ] `make run_all` が成功する