### PR TITLE
make を叩けるようにする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM node:12-slim AS base

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 IMAGE_NAME ?= image_assembly_line/dev
+NODE_VERSION ?= 12
 
 build:
 	echo "hello"
 
 build_dev_image:
 	docker build -f dev.Dockerfile \
+		--build-arg NODE_VERSION=${NODE_VERSION} \
 		-t ${IMAGE_NAME} .
 
 run_all:

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ run_all:
 		-v ${PWD}/lib:/app/lib \
 		-v ${PWD}/dist:/app/dist \
 		-v ${PWD}/__tests__:/app/__tests__ \
+		-t ${IMAGE_NAME}:latest \
 		sh -c 'npm run all'
 
 build_test:

--- a/__tests__/docker.test.ts
+++ b/__tests__/docker.test.ts
@@ -1,0 +1,12 @@
+import {build} from '../src/docker'
+
+test('build', async () => {
+  // 成功して結果が 0 であること
+  expect(
+    await build(
+      '1234567890.dkr.ecr.ap-northeast-1.amazonaws.com/',
+      'imagename/app',
+      'build'
+    )
+  ).toEqual(0)
+})

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,24 +1,11 @@
-import {wait} from '../src/wait'
 import * as process from 'process'
 import * as cp from 'child_process'
 import * as path from 'path'
 
-test('throws invalid number', async () => {
-  const input = parseInt('foo', 10)
-  await expect(wait(input)).rejects.toThrow('milliseconds not a number')
-})
-
-test('wait 500 ms', async () => {
-  const start = new Date()
-  await wait(500)
-  const end = new Date()
-  var delta = Math.abs(end.getTime() - start.getTime())
-  expect(delta).toBeGreaterThan(450)
-})
-
 // shows how the runner will run a javascript action with env / stdout protocol
 test('test runs', () => {
   process.env['INPUT_MILLISECONDS'] = '500'
+  process.env['INPUT_IMAGE_NAME'] = 'imagename/app'
   process.env['REGISTRY_NAME'] =
     '1234567890.dkr.ecr.ap-northeast-1.amazonaws.com'
   const ip = path.join(__dirname, '..', 'lib', 'main.js')

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,11 @@ inputs:
   myInput:              # change this
     description: 'input description here'
     default: 'default value if applicable'
+  image_name:
+    require: true
+  target:
+    description: 'make target'
+    default: 'build'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -2,9 +2,6 @@ name: 'Image Assembly Line'
 description: 'GitHub Action that runs our docker image build flow.'
 author: 'freee K.K.'
 inputs:
-  myInput:              # change this
-    description: 'input description here'
-    default: 'default value if applicable'
   image_name:
     require: true
   target:

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,4 +1,6 @@
-FROM node:12-slim AS base
+ARG NODE_VERSION
+
+FROM node:$NODE_VERSION-slim AS base
 RUN apt update \
     && apt install icu-devtools git sudo curl ca-certificates build-essential unzip openssh-client -y --no-install-recommends
 WORKDIR /app

--- a/dist/index.js
+++ b/dist/index.js
@@ -971,24 +971,24 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
-const exec = __importStar(__webpack_require__(986));
-const wait_1 = __webpack_require__(521);
+// import * as exec from '@actions/exec'
+// import {wait} from './wait'
+const docker_1 = __webpack_require__(231);
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            const ms = core.getInput('milliseconds');
-            core.debug(`Waiting ${ms} milliseconds ...`);
-            const target = 'hello';
+            // REGISTRY_NAME はユーザー側から渡せない様にする
             const registry = process.env.REGISTRY_NAME;
             if (registry === undefined) {
                 throw new Error('REGISTRY_NAME is not set.');
             }
             core.debug(registry);
-            exec.exec(`echo ${target}`);
-            core.debug(new Date().toTimeString());
-            yield wait_1.wait(parseInt(ms, 10));
-            core.debug(new Date().toTimeString());
-            core.setOutput('time', new Date().toTimeString());
+            const target = core.getInput('target');
+            core.debug(`target: ${target}`);
+            const imageName = core.getInput('image_name');
+            core.debug(`image_name: ${imageName}`);
+            docker_1.build(registry, imageName, target);
+            // push(registry, imageName)
         }
         catch (error) {
             core.setFailed(error.message);
@@ -996,6 +996,48 @@ function run() {
     });
 }
 run();
+
+
+/***/ }),
+
+/***/ 231:
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const core = __importStar(__webpack_require__(470));
+const exec = __importStar(__webpack_require__(986));
+function build(registry, imageName, target) {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+            const result = yield exec.exec(`make REGISTRY_NAME=${registry} IMAGE_NAME=${imageName} ${target}`);
+            core.debug(`build(): ${result.toString()}`);
+            return result;
+        }
+        catch (e) {
+            core.debug('build() error');
+            throw e;
+        }
+    });
+}
+exports.build = build;
 
 
 /***/ }),
@@ -1279,36 +1321,6 @@ function getState(name) {
 }
 exports.getState = getState;
 //# sourceMappingURL=core.js.map
-
-/***/ }),
-
-/***/ 521:
-/***/ (function(__unusedmodule, exports) {
-
-"use strict";
-
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-function wait(milliseconds) {
-    return __awaiter(this, void 0, void 0, function* () {
-        return new Promise(resolve => {
-            if (isNaN(milliseconds)) {
-                throw new Error('milliseconds not a number');
-            }
-            setTimeout(() => resolve('done!'), milliseconds);
-        });
-    });
-}
-exports.wait = wait;
-
 
 /***/ }),
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -977,7 +977,7 @@ function run() {
         try {
             // REGISTRY_NAME はユーザー側から渡せない様にする
             const registry = process.env.REGISTRY_NAME;
-            if (registry === undefined) {
+            if (!registry) {
                 throw new Error('REGISTRY_NAME is not set.');
             }
             core.debug(registry);

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -1,0 +1,19 @@
+import * as core from '@actions/core'
+import * as exec from '@actions/exec'
+
+export async function build(
+  registry: string,
+  imageName: string,
+  target: string
+): Promise<number> {
+  try {
+    const result = await exec.exec(
+      `make REGISTRY_NAME=${registry} IMAGE_NAME=${imageName} ${target}`
+    )
+    core.debug(`build(): ${result.toString()}`)
+    return result
+  } catch (e) {
+    core.debug('build() error')
+    throw e
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,26 +1,22 @@
 import * as core from '@actions/core'
-import * as exec from '@actions/exec'
-import {wait} from './wait'
+import {build} from './docker'
 
 async function run(): Promise<void> {
   try {
-    const ms: string = core.getInput('milliseconds')
-    core.debug(`Waiting ${ms} milliseconds ...`)
-    const target = 'hello'
-
+    // REGISTRY_NAME はユーザー側から渡せない様にする
     const registry: string | undefined = process.env.REGISTRY_NAME
     if (registry === undefined) {
       throw new Error('REGISTRY_NAME is not set.')
     }
     core.debug(registry)
 
-    exec.exec(`echo ${target}`)
+    const target = core.getInput('target')
+    core.debug(`target: ${target}`)
 
-    core.debug(new Date().toTimeString())
-    await wait(parseInt(ms, 10))
-    core.debug(new Date().toTimeString())
+    const imageName = core.getInput('image_name')
+    core.debug(`image_name: ${imageName}`)
 
-    core.setOutput('time', new Date().toTimeString())
+    build(registry, imageName, target)
   } catch (error) {
     core.setFailed(error.message)
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ async function run(): Promise<void> {
   try {
     // REGISTRY_NAME はユーザー側から渡せない様にする
     const registry: string | undefined = process.env.REGISTRY_NAME
-    if (registry === undefined) {
+    if (!registry) {
       throw new Error('REGISTRY_NAME is not set.')
     }
     core.debug(registry)


### PR DESCRIPTION
# 概要
image_assembly_line フェーズ1 の中の build が通るようになるという部分です。
https://jira-freee.atlassian.net/browse/CONTAINER-30

# やったこと
* `build()` を追加
    * 簡単な test を追加
* テスト用に Makefile を追加

# やってないこと
* push の実装
* REGISTRY_NAME を runner に追加すること

# 確認
- [x] このブランチを使って [build-image が make build 成功していること](https://github.com/C-FO/build-image/runs/607051284?check_suite_focus=true)
- [ ] `npm run build && npm run test` or `make build_test` が通ること
